### PR TITLE
fix: update VS Code compatibility from ^1.102.0 to ^1.80.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "icon": "icon.png",
     "engines": {
         "node": ">=20.0.0",
-        "vscode": "^1.102.0"
+        "vscode": "^1.80.0"
     },
     "categories": [
         "Other"
@@ -129,7 +129,7 @@
     },
     "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.102.0",
+        "@types/vscode": "^1.80.0",
         "@vscode/vsce": "^3.0.0",
         "typescript": "^5.0.0",
         "eslint": "^8.57.0",


### PR DESCRIPTION
- Lower VS Code engine requirement to support older versions
- Update @types/vscode dependency to match new engine requirement
- Resolves compatibility issue with VS Code 1.99.3

## Description

[Description of the changes made in this pull request]

## Related Issues

- Fixes #<issue_number>

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have reviewed my own code for any potential issues
- [ ] I have requested reviews from appropriate team members

## Screenshots (if applicable)

[Attach screenshots or GIFs to demonstrate the changes visually]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened extension compatibility to support VS Code 1.80 and later, enabling installation on more environments.
  * Updated development typings to align with the new compatibility baseline; no changes to features, settings, or commands.
  * No functional changes—performance and behavior remain the same.
  * Users previously blocked by stricter version requirements should now be able to install and use the extension without issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->