### PR TITLE
fix: add conventionalcommits preset to detect breaking changes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,13 +2,13 @@
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
       "releaseRules": [
         { "type": "feat", "release": "minor" },
         { "type": "fix", "release": "patch" },
         { "type": "perf", "release": "patch" },
         { "type": "refactor", "release": "patch" },
-        { "type": "docs", "release": "patch" },
-        { "breaking": true, "release": "major" }
+        { "type": "docs", "release": "patch" }
       ]
     }],
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
The previous configuration was not detecting breaking changes indicated by the '!' suffix in commit types (e.g., feat!:).

Changes:
- Added preset: 'conventionalcommits' to @semantic-release/commit-analyzer
- This preset automatically detects breaking changes from:
  - '!' suffix in commit type (feat!: → major release)
  - 'BREAKING CHANGE:' footer in commit body → major release
- Removed redundant breaking: true rule as preset handles it

This fixes the issue where 'feat!:' commits were not triggering major releases as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

[Description of the changes made in this pull request]

## Related Issues

- Fixes #<issue_number>

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have reviewed my own code for any potential issues
- [ ] I have requested reviews from appropriate team members

## Screenshots (if applicable)

[Attach screenshots or GIFs to demonstrate the changes visually]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to follow conventional commit standards for improved version management and consistency in release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->