### PR TITLE
feat!: require kubeseal binary in PATH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,6 @@ src/
 ```typescript
 kubeseal.certsFolder: string       // Path to certificate folder
 kubeseal.activeCertFile: string    // Filename of active certificate
-kubeseal.kubesealPath: string      // Path to kubeseal binary (default: "kubeseal")
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The extension provides the following settings:
 
 - `kubeseal.certsFolder`: Path to the folder containing kubeseal certificate files (\*.pem, \*.crt, \*.cert)
 - `kubeseal.activeCertFile`: Filename of the currently active certificate in the certs folder
-- `kubeseal.kubesealPath`: Path to the kubeseal binary (default: "kubeseal")
 
 ## 🎮 Commands
 

--- a/package.json
+++ b/package.json
@@ -107,11 +107,6 @@
                     "type": "string",
                     "default": "",
                     "description": "Filename of the currently active certificate in the certs folder"
-                },
-                "kubeseal.kubesealPath": {
-                    "type": "string",
-                    "default": "kubeseal",
-                    "description": "Path to the kubeseal binary"
                 }
             }
         }

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -29,8 +29,6 @@ export async function encryptSecret(
         if (token?.isCancellationRequested) {
             return;
         }
-        const config = vscode.workspace.getConfiguration('kubeseal');
-        const kubesealPath = config.get<string>('kubesealPath', 'kubeseal');
 
         // Get certificate path using certificate management system
         const certPath = await getCurrentCertificatePath(progress, token);
@@ -79,7 +77,7 @@ export async function encryptSecret(
             throw new Error('Cancellation token is required');
         }
 
-        await execKubeseal(kubesealPath, certPath, filePath, outputPath, token);
+        await execKubeseal(certPath, filePath, outputPath, token);
 
         // Check for cancellation before showing success message
         if (token?.isCancellationRequested) {

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -76,14 +76,12 @@ export async function execWithCancellation(
 
 /**
  * Executes kubeseal command to encrypt a secret
- * @param kubesealPath Path to kubeseal binary
  * @param certPath Path to certificate file
  * @param inputPath Path to input YAML file
  * @param outputPath Path to output YAML file
  * @param token Cancellation token
  */
 export async function execKubeseal(
-    kubesealPath: string,
     certPath: string,
     inputPath: string,
     outputPath: string,
@@ -93,7 +91,7 @@ export async function execKubeseal(
     const inputContent = await fs.readFile(inputPath, 'utf8');
 
     // Execute kubeseal with stdin/stdout
-    const child = spawn(kubesealPath, ['--cert', certPath, '--format', 'yaml'], {
+    const child = spawn('kubeseal', ['--cert', certPath, '--format', 'yaml'], {
         stdio: ['pipe', 'pipe', 'pipe']
     });
 


### PR DESCRIPTION
Remove kubeseal.kubesealPath configuration setting and require users to have kubeseal installed in their system PATH. This simplifies configuration and follows standard practices for CLI tool integration.

BREAKING CHANGE: The kubeseal.kubesealPath configuration setting has been removed. Users must now ensure the kubeseal binary is available in their system PATH. If you previously configured a custom path to kubeseal, you will need to either:
- Add the kubeseal binary location to your PATH environment variable, or
- Create a symlink to kubeseal in a directory that is already in your PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

[Description of the changes made in this pull request]

## Related Issues

- Fixes #<issue_number>

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have reviewed my own code for any potential issues
- [ ] I have requested reviews from appropriate team members

## Screenshots (if applicable)

[Attach screenshots or GIFs to demonstrate the changes visually]
