### PR TITLE
fix: bundle js-yaml dependency in extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+!node_modules/js-yaml/**
 
 # Build artifacts
 *.ts


### PR DESCRIPTION
The extension was failing to activate with error "Cannot find module 'js-yaml'" because the js-yaml dependency was not being included in the VSIX package.

The .vscodeignore file was excluding all of node_modules/, which prevented the js-yaml runtime dependency from being bundled with the extension.

This commit adds an exception to .vscodeignore to include node_modules/js-yaml/** so the dependency is packaged and available at runtime.

Fixes extension activation issue where VS Code could not load the extension due to missing js-yaml module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

[Description of the changes made in this pull request]

## Related Issues

- Fixes #<issue_number>

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have reviewed my own code for any potential issues
- [ ] I have requested reviews from appropriate team members

## Screenshots (if applicable)

[Attach screenshots or GIFs to demonstrate the changes visually]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging configuration to ensure dependencies are properly included in distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->